### PR TITLE
error_logger: Pass peer to error logger

### DIFF
--- a/error_logger/error_logger.go
+++ b/error_logger/error_logger.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/upfluence/pkg/error_logger/noop"
 	"github.com/upfluence/pkg/error_logger/sentry"
+	"github.com/upfluence/pkg/peer"
 )
 
 var DefaultErrorLogger ErrorLogger
@@ -22,7 +23,7 @@ func IgnoreError(err error) func(error) bool {
 
 func init() {
 	if v := os.Getenv("SENTRY_DSN"); v != "" {
-		l, err := sentry.NewErrorLogger(v)
+		l, err := sentry.NewErrorLogger(v, peer.FromEnv())
 
 		if err != nil {
 			DefaultErrorLogger = noop.NewErrorLogger()


### PR DESCRIPTION
Try to fix issue from ubuild 
```
# github.com/upfluence/pkg/error_logger
../pkg/error_logger/error_logger.go:25:34: not enough arguments in call to sentry.NewErrorLogger
	have (string)
	want (string, *peer.Peer)
Exited with code 2
```