### PR TITLE
intervalpush/: Make the exporter cleanly stopable.

### DIFF
--- a/prometheus/exporter/exporter.go
+++ b/prometheus/exporter/exporter.go
@@ -1,5 +1,9 @@
 package exporter
 
+import "io"
+
 type Exporter interface {
+	io.Closer
+
 	Export(<-chan bool)
 }

--- a/prometheus/exporter/intervalpush/exporter.go
+++ b/prometheus/exporter/intervalpush/exporter.go
@@ -44,8 +44,10 @@ func (e *exporter) Export(exitChan <-chan bool) {
 		for {
 			select {
 			case <-exitChan:
+				e.t.Stop()
 				return
 			case <-ctx.Done():
+				e.t.Stop()
 				if err := e.p.Push(); err != nil {
 					log.Noticef("Push to gatherer failed: %s", err.Error())
 				}

--- a/thrift/serializer/struct_test.go
+++ b/thrift/serializer/struct_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/upfluence/thrift/lib/go/thrift"
 )
 
@@ -36,17 +37,16 @@ func TestStringSerialization(t *testing.T) {
 }
 
 func TestMapSerialization(t *testing.T) {
-	vs := map[string]TStruct{
-		"foo": &stringTStruct{"bar"},
-		"biz": &stringTStruct{"buz"},
-	}
+	var (
+		dvs = make(map[string]TStruct)
+		vs  = map[string]TStruct{
+			"foo": &stringTStruct{"bar"},
+			"biz": &stringTStruct{"buz"},
+		}
+	)
 
 	out, err := NewDefaultTSerializer().WriteString(MapWriter(vs))
-
-	assert.Nil(t, err)
-	assert.Equal(t, "[\"str\",\"rec\",2,{\"foo\":\"bar\",\"biz\":\"buz\"}]", out)
-
-	dvs := make(map[string]TStruct)
+	require.NoError(t, err)
 
 	err = NewDefaultTDeserializer().ReadString(
 		MapReader(func(k string, p thrift.TProtocol) error {
@@ -62,6 +62,6 @@ func TestMapSerialization(t *testing.T) {
 		out,
 	)
 
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, vs, dvs)
 }


### PR DESCRIPTION
### What does this PR do ?

This PR makes the `intervalpush/exporter` expose a `Close()` method to allow gracefully stopping it. By calling close, it ensures that push is Called properly is called before exiting.

This change is made in a retro compatible manner, which means:
- The old `chan` mechanism is left in place. 
- ~We don't change the public interface and require to downcast the `Exporter` interface as `io.Closer` in order to use the graceful stop.~ actually we expose io.Closer.