### PR TITLE
Add delete helper on stringutil.Set and int64util.set

### DIFF
--- a/int64util/set.go
+++ b/int64util/set.go
@@ -46,3 +46,9 @@ func (s *Set) Has(v int64) bool {
 	_, ok := s.Set[v]
 	return ok
 }
+
+func (s *Set) Delete(vv ...int64) {
+	for _, v := range vv {
+		delete(s.Set, v)
+	}
+}

--- a/int64util/set_test.go
+++ b/int64util/set_test.go
@@ -54,6 +54,22 @@ func TestHas(t *testing.T) {
 	assert.False(t, s.Has(8))
 }
 
+func TestDelete(t *testing.T) {
+	var s Set
+
+	s.Add(3)
+	s.Add(4)
+	s.Add(5)
+	assert.True(t, s.Has(3))
+	assert.True(t, s.Has(4))
+	assert.True(t, s.Has(5))
+
+	s.Delete(4, 5)
+	assert.True(t, s.Has(3))
+	assert.False(t, s.Has(4))
+	assert.False(t, s.Has(5))
+}
+
 func assertElementsMatch(ss ...int64) assertInt64s {
 	return func(t *testing.T, es []int64) { assert.ElementsMatch(t, es, ss) }
 }

--- a/stringutil/set.go
+++ b/stringutil/set.go
@@ -48,3 +48,9 @@ func (s *Set) Strings() []string {
 
 	return res
 }
+
+func (s *Set) Delete(vs ...string) {
+	for _, v := range vs {
+		delete(s.Set, v)
+	}
+}

--- a/stringutil/set_test.go
+++ b/stringutil/set_test.go
@@ -53,6 +53,24 @@ func TestHas(t *testing.T) {
 	assert.False(t, s.Has("bar"))
 }
 
+func TestDelete(t *testing.T) {
+	var s Set
+
+	assert.False(t, s.Has("foo"))
+
+	s.Add("foo")
+	s.Add("bar")
+	s.Add("biz")
+	assert.True(t, s.Has("foo"))
+	assert.True(t, s.Has("bar"))
+	assert.True(t, s.Has("biz"))
+
+	s.Delete("bar", "biz")
+	assert.True(t, s.Has("foo"))
+	assert.False(t, s.Has("bar"))
+	assert.False(t, s.Has("biz"))
+}
+
 func assertElementsMatch(ss ...string) assertStrings {
 	return func(t *testing.T, es []string) { assert.ElementsMatch(t, es, ss) }
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds Delete method to int64util and stringutil sets.

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled