### PR TITLE
iopool: Add telemery for pool contention

### DIFF
--- a/iopool/metrics.go
+++ b/iopool/metrics.go
@@ -1,0 +1,32 @@
+package iopool
+
+import "github.com/upfluence/stats"
+
+type metrics struct {
+	get     stats.Counter
+	put     stats.Counter
+	discard stats.Counter
+
+	getWait         stats.Counter
+	getWaitDuration stats.Counter
+
+	idleClosed stats.Counter
+
+	idle     stats.Gauge
+	checkout stats.Gauge
+	size     stats.Gauge
+}
+
+func newMetrics(s stats.Scope) metrics {
+	return metrics{
+		get:             s.Counter("get_total"),
+		put:             s.Counter("put_total"),
+		discard:         s.Counter("discard_total"),
+		getWait:         s.Counter("get_wait_total"),
+		getWaitDuration: s.Counter("get_wait_millisecond_total"),
+		idleClosed:      s.Counter("entity_idle_closed_total"),
+		idle:            s.Gauge("idle"),
+		checkout:        s.Gauge("checkout"),
+		size:            s.Gauge("size"),
+	}
+}

--- a/iopool/options.go
+++ b/iopool/options.go
@@ -1,0 +1,85 @@
+package iopool
+
+import (
+	"time"
+
+	"github.com/upfluence/pkg/cache/policy"
+	ptime "github.com/upfluence/pkg/cache/policy/time"
+	"github.com/upfluence/stats"
+)
+
+var defaultOptions = &options{
+	size:     10,
+	idleSize: 5,
+	sc:       stats.RootScope(stats.NewStaticCollector()),
+	scfn:     func(sc stats.Scope) stats.Scope { return sc },
+}
+
+type options struct {
+	size     int
+	idleSize int
+
+	eps []policy.EvictionPolicy
+
+	sc   stats.Scope
+	scfn func(stats.Scope) stats.Scope
+}
+
+func newOptions(opts ...Option) *options {
+	var o = *defaultOptions
+
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	return &o
+}
+
+func (o *options) scope() stats.Scope { return o.scfn(o.sc) }
+
+func (o *options) evictionPolicy() policy.EvictionPolicy {
+	return policy.CombinePolicies(o.eps...)
+}
+
+type Option func(*options)
+
+func WithIdleTimeout(d time.Duration) Option {
+	return func(o *options) {
+		o.eps = append(o.eps, ptime.NewIdlePolicy(d))
+	}
+}
+
+func WithScope(s stats.Scope) Option {
+	return func(o *options) { o.sc = s }
+}
+
+func WithStandardizedMetrics(n string) Option {
+	return func(o *options) {
+		o.scfn = func(sc stats.Scope) stats.Scope {
+			return sc.RootScope().Scope(
+				"upfluence_iopool_pool",
+				map[string]string{"pool": n},
+			)
+		}
+	}
+}
+
+func WithMaxIdle(s int) Option {
+	return func(o *options) {
+		o.idleSize = s
+
+		if s > o.size {
+			o.size = s
+		}
+	}
+}
+
+func WithSize(s int) Option {
+	return func(o *options) {
+		o.size = s
+
+		if o.idleSize > s {
+			o.idleSize = s
+		}
+	}
+}

--- a/iopool/pool.go
+++ b/iopool/pool.go
@@ -10,10 +10,8 @@ import (
 	"time"
 
 	"github.com/upfluence/pkg/cache/policy"
-	ptime "github.com/upfluence/pkg/cache/policy/time"
 	"github.com/upfluence/pkg/closer"
 	"github.com/upfluence/pkg/multierror"
-	"github.com/upfluence/stats"
 )
 
 var (
@@ -30,30 +28,6 @@ type Entity interface {
 	IsOpen() bool
 }
 
-type poolMetrics struct {
-	get     stats.Counter
-	put     stats.Counter
-	discard stats.Counter
-
-	idleClosed stats.Counter
-
-	idle     stats.Gauge
-	checkout stats.Gauge
-	size     stats.Gauge
-}
-
-func newPoolMetrics(s stats.Scope) poolMetrics {
-	return poolMetrics{
-		get:        s.Counter("get_total"),
-		put:        s.Counter("put_total"),
-		discard:    s.Counter("discard_total"),
-		idleClosed: s.Counter("entity_idle_closed_total"),
-		idle:       s.Gauge("idle"),
-		checkout:   s.Gauge("checkout"),
-		size:       s.Gauge("size"),
-	}
-}
-
 type entityWrapper struct {
 	e Entity
 	n string
@@ -62,8 +36,10 @@ type entityWrapper struct {
 }
 
 type Pool struct {
-	*options
 	*closer.Monitor
+
+	size     int
+	idleSize int
 
 	closeOnce sync.Once
 
@@ -79,80 +55,28 @@ type Pool struct {
 
 	ep      policy.EvictionPolicy
 	cnt     uint64
-	metrics poolMetrics
-}
-
-type options struct {
-	size     int
-	idleSize int
-
-	eps []policy.EvictionPolicy
-
-	scope stats.Scope
-}
-
-type Option func(*options)
-
-func WithIdleTimeout(d time.Duration) Option {
-	return func(o *options) {
-		o.eps = append(o.eps, ptime.NewIdlePolicy(d))
-	}
-}
-
-func WithScope(s stats.Scope) Option {
-	return func(o *options) { o.scope = s }
-}
-
-func WithMaxIdle(s int) Option {
-	return func(o *options) {
-		o.idleSize = s
-
-		if s > o.size {
-			o.size = s
-		}
-	}
-}
-
-func WithSize(s int) Option {
-	return func(o *options) {
-		o.size = s
-
-		if o.idleSize > s {
-			o.idleSize = s
-		}
-	}
-}
-
-var defaultOptions = &options{
-	size:     10,
-	idleSize: 5,
-	scope:    stats.RootScope(stats.NewStaticCollector()),
+	metrics metrics
 }
 
 func NewPool(f Factory, opts ...Option) *Pool {
-	options := *defaultOptions
-
-	for _, opt := range opts {
-		opt(&options)
-	}
-
+	o := newOptions(opts...)
 	p := Pool{
+		size:       o.size,
+		idleSize:   o.idleSize,
 		Monitor:    closer.NewMonitor(),
 		factory:    f,
-		options:    &options,
-		createc:    make(chan struct{}, options.size),
-		poolc:      make(chan *entityWrapper, options.idleSize),
+		createc:    make(chan struct{}, o.size),
+		poolc:      make(chan *entityWrapper, o.idleSize),
 		checkedout: make(map[Entity]*entityWrapper),
 		checkout:   make(map[string]*entityWrapper),
 		checkin:    make(map[string]*entityWrapper),
-		ep:         policy.CombinePolicies(options.eps...),
+		ep:         o.evictionPolicy(),
 	}
 
-	p.metrics = newPoolMetrics(options.scope)
+	p.metrics = newMetrics(o.scope())
+	p.metrics.size.Update(int64(o.size))
 
-	p.metrics.size.Update(int64(options.size))
-
-	for i := 0; i < options.size; i++ {
+	for i := 0; i < o.size; i++ {
 		p.createc <- struct{}{}
 	}
 
@@ -232,6 +156,12 @@ func (p *Pool) Get(ctx context.Context) (Entity, error) {
 		return e, err
 	}
 
+	t0 := time.Now()
+	checkout := func() {
+		p.metrics.getWait.Inc()
+		p.metrics.getWaitDuration.Add(time.Since(t0).Milliseconds())
+	}
+
 	for {
 		select {
 		case <-p.Context().Done():
@@ -244,6 +174,7 @@ func (p *Pool) Get(ctx context.Context) (Entity, error) {
 			}
 
 			if p.checkoutWrapper(ew) {
+				checkout()
 				return ew.e, nil
 			}
 		case _, ok := <-p.createc:
@@ -263,6 +194,7 @@ func (p *Pool) Get(ctx context.Context) (Entity, error) {
 			}
 
 			p.markOut(ew)
+			checkout()
 
 			return ew.e, nil
 		}

--- a/iopool/pool.go
+++ b/iopool/pool.go
@@ -248,6 +248,11 @@ func (p *Pool) requeue(ew *entityWrapper) error {
 	case p.poolc <- ew:
 		p.metrics.idle.Update(int64(len(p.poolc)))
 	default:
+		select {
+		case p.createc <- struct{}{}:
+		default:
+		}
+
 		return ew.e.Close()
 	}
 


### PR DESCRIPTION
### What does this PR do?

In various application i noticed the latency on client side drifting from the latency on server side. I suspect some pool contention in thrift client / amqp channel pool. In order to figure it out i add some metrics aroudn contention.


### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

I did not update any test given the fact it is hard to have adeterministic value  to be returned and knowing it in the oracle is impossible
