### PR TITLE
syncutil: Add KeyedSingleflight struct

### DIFF
--- a/syncutil/keyed_singleflight.go
+++ b/syncutil/keyed_singleflight.go
@@ -1,0 +1,61 @@
+package syncutil
+
+import (
+	"context"
+	"sync"
+)
+
+type KeyedSingleflight struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	once   sync.Once
+
+	mu  sync.Mutex
+	sfs map[string]*Singleflight
+}
+
+func (ksf *KeyedSingleflight) init() {
+	ksf.once.Do(func() {
+		ksf.ctx, ksf.cancel = context.WithCancel(context.Background())
+		ksf.sfs = make(map[string]*Singleflight)
+	})
+}
+
+func (ksf *KeyedSingleflight) Do(ctx context.Context, key string, fn func(context.Context) error) (bool, error) {
+	ksf.init()
+
+	ksf.mu.Lock()
+
+	sf, ok := ksf.sfs[key]
+
+	if !ok {
+		sf = &Singleflight{ctx: ksf.ctx, cancel: ksf.cancel}
+		ksf.sfs[key] = sf
+	}
+
+	ksf.mu.Unlock()
+
+	return sf.Do(
+		ctx,
+		func(ctx context.Context) error {
+			err := fn(ctx)
+
+			ksf.mu.Lock()
+			delete(ksf.sfs, key)
+			ksf.mu.Unlock()
+
+			return err
+		},
+	)
+}
+
+func (ksf *KeyedSingleflight) Close() error {
+	ksf.init()
+	ksf.cancel()
+
+	for _, sf := range ksf.sfs {
+		sf.wg.Wait()
+	}
+
+	return nil
+}

--- a/syncutil/keyed_singleflight_test.go
+++ b/syncutil/keyed_singleflight_test.go
@@ -1,0 +1,63 @@
+package syncutil
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeyedSingleflight(t *testing.T) {
+	var (
+		ksf KeyedSingleflight
+		wg  sync.WaitGroup
+
+		ctx   = context.Background()
+		donec = make(chan struct{})
+	)
+
+	wg.Add(3)
+
+	go func() {
+		ok, _ := ksf.Do(ctx, "foo", func(context.Context) error {
+			<-donec
+			return nil
+		})
+
+		assert.True(t, ok)
+		wg.Done()
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+
+	go func() {
+		ok, _ := ksf.Do(ctx, "bar", func(context.Context) error {
+			<-donec
+			return nil
+		})
+
+		assert.True(t, ok)
+		wg.Done()
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+
+	go func() {
+		ok, _ := ksf.Do(ctx, "foo", func(context.Context) error {
+			<-donec
+			return nil
+		})
+
+		assert.False(t, ok)
+		wg.Done()
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	close(donec)
+
+	wg.Wait()
+
+	assert.Equal(t, 0, len(ksf.sfs))
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds a small "helper" struct that allows to do multiple Singleflight structs cluster by string key. It is rather similar to `*golang.org/x/sync/singleflight.Singleflight` but it is:
*  context-aware, if you context get canceled and you are not the executor you can give up
*  closable, you can close the entire struct and unlock all goroutines.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
