### PR TITLE
Cache/policy/time: Backup next before deleting current list elem

### DIFF
--- a/cache/policy/time/policy.go
+++ b/cache/policy/time/policy.go
@@ -151,7 +151,9 @@ func (p *Policy) cleanup(now int64) {
 	ee := e.Value.(element)
 
 	for ee.t+p.ttl < now {
+		next := e.Next()
 		p.l.Remove(e)
+		e = next
 
 		k := ee.key
 		select {
@@ -160,8 +162,6 @@ func (p *Policy) cleanup(now int64) {
 		}
 
 		delete(p.ks, k)
-
-		e = e.Next()
 
 		if e == nil {
 			return


### PR DESCRIPTION
### What does this PR do?

Fix an issue with the time policy that prevent it from evicting more than one element at a time.

Fixes https://github.com/upfluence/backlog/issues/1086

### What are the observable changes?

backup next before deleting current

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
