### PR TITLE
timeutil: Add an helper for get the unix or nil value

### DIFF
--- a/timeutil/utils.go
+++ b/timeutil/utils.go
@@ -1,0 +1,16 @@
+package timeutil
+
+import (
+	"time"
+
+	"github.com/upfluence/pkg/pointers"
+)
+
+// UnixOrrNil returns the unix timestamp or nil if time is zero.
+func UnixOrNil(t time.Time) *int64 {
+	if t.IsZero() {
+		return nil
+	}
+
+	return pointers.Ptr(t.Unix())
+}

--- a/timeutil/utils_test.go
+++ b/timeutil/utils_test.go
@@ -1,0 +1,15 @@
+package timeutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnixOrNil(t *testing.T) {
+	var n *int64
+
+	assert.Equal(t, UnixOrNil(time.Time{}), n)
+	assert.Equal(t, *UnixOrNil(time.Unix(123456, 0)), time.Unix(123456, 0).Unix())
+}


### PR DESCRIPTION
### What does this PR do?

Add an helper to convert time to unix or nil.

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [X] Title makes sense
- [X] Is against the correct branch
- [X] Only addresses one issue
- [X] Properly assigned
- [X] Added/updated tests
- [ ] Added/updated documentation
- [ ] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
