### PR TITLE
timeutil/timetest: Keep the mutex of `timetest.Clock` private

### DIFF
--- a/timeutil/timetest/time.go
+++ b/timeutil/timetest/time.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Clock struct {
-	sync.RWMutex
+	mu sync.RWMutex
 
 	now time.Time
 
@@ -17,15 +17,15 @@ type Clock struct {
 }
 
 func (c *Clock) MoveTo(t time.Time) {
-	c.Lock()
+	c.mu.Lock()
 	c.moveTo(t)
-	c.Unlock()
+	c.mu.Unlock()
 }
 
 func (c *Clock) MoveBy(d time.Duration) {
-	c.Lock()
+	c.mu.Lock()
 	c.moveTo(c.now.Add(d))
-	c.Unlock()
+	c.mu.Unlock()
 }
 
 func (c *Clock) moveTo(n time.Time) {
@@ -41,7 +41,7 @@ func (c *Clock) moveTo(n time.Time) {
 }
 
 func (c *Clock) newTimer(d time.Duration, fn func()) *timer {
-	c.Lock()
+	c.mu.Lock()
 	t := timer{
 		c:        make(chan time.Time, 1),
 		now:      c.now,
@@ -50,7 +50,7 @@ func (c *Clock) newTimer(d time.Duration, fn func()) *timer {
 	}
 
 	c.timers = append(c.timers, &t)
-	c.Unlock()
+	c.mu.Unlock()
 
 	return &t
 }
@@ -64,7 +64,7 @@ func (c *Clock) TimerFunc(d time.Duration, fn func()) timeutil.Timer {
 }
 
 func (c *Clock) Ticker(d time.Duration) timeutil.Ticker {
-	c.Lock()
+	c.mu.Lock()
 	t := ticker{
 		c: make(chan time.Time, 1),
 		d: d,
@@ -72,15 +72,15 @@ func (c *Clock) Ticker(d time.Duration) timeutil.Ticker {
 	}
 
 	c.tickers = append(c.tickers, &t)
-	c.Unlock()
+	c.mu.Unlock()
 
 	return &t
 }
 
 func (c *Clock) Now() time.Time {
-	c.RLock()
+	c.mu.RLock()
 	t := c.now
-	c.RUnlock()
+	c.mu.RUnlock()
 
 	return t
 }


### PR DESCRIPTION
### What does this PR do?

I ran `grep -rF --include '*.go' .RWMutex.` on the repos and found nothing so it should not break anything 🤔 

`gopls` completions before/after hiding the mutex on `timetest.Clock `

![hide](https://github.com/upfluence/pkg/assets/145350443/c64c7647-0a11-4e33-b17b-2ce7fb9f782a)

Fixes #<!-- enter issue number here -->

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [ ] Title makes sense
- [ ] Is against the correct branch
- [ ] Only addresses one issue
- [ ] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
