### PR TITLE
thrift/thriftutil/enums: avoid duplicating underscores

### DIFF
--- a/thrift/thriftutil/enums.go
+++ b/thrift/thriftutil/enums.go
@@ -8,7 +8,7 @@ import (
 
 func SanitizeCamelCaseThriftEnumValue(v string) string {
 	if sks := strings.SplitN(v, "_", 2); len(sks) == 2 {
-		return stringutil.CamelToSnakeCase(sks[1])
+		return strings.ReplaceAll(stringutil.CamelToSnakeCase(sks[1]), "__", "_")
 	}
 
 	return strings.ToLower(v)

--- a/thrift/thriftutil/enums_test.go
+++ b/thrift/thriftutil/enums_test.go
@@ -12,6 +12,7 @@ func TestSanitizeCamelCaseThriftEnumValue(t *testing.T) {
 		{"ContentType_InstagramMedia", "instagram_media"},
 		{"ContentType_Unknown", "unknown"},
 		{"regular string", "regular string"},
+		{"MFAVector_RECOVERY_CODE", "recovery_code"},
 	} {
 		if out := SanitizeCamelCaseThriftEnumValue(tt.in); tt.out != out {
 			t.Errorf("SanitizeCamelCaseThriftEnumValue(%q) = %q wanted: %q", tt.in, out, tt.out)


### PR DESCRIPTION
### What does this PR do?

:warning: NOTE: this is actually to patch the behaviour of the underlying `CamelCaseToSnakeCase` func. I could have put it in that func directly, however:
- It's called **CamelCase**ToSnakeCase, and Camel Case does not accept underscores. It kind of makes sense that it'd cause issues with underscores then
- If we start planning for underscores then, won't we have more bad surprises later on?
- It makes more sense to patch its output in the thrift func where the case is not exactly respected imo

Can easily change it back if needs be

Fixes #<!-- enter issue number here -->

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [ ] Title makes sense
- [ ] Is against the correct branch
- [ ] Only addresses one issue
- [ ] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
