### PR TITLE
country/code_fetcher.go: prevent records with smaller assignment priority from overwriting those with higher priority

### DIFF
--- a/country/code_fetcher.go
+++ b/country/code_fetcher.go
@@ -146,10 +146,8 @@ func (icf *IndexedCodeFetcher) prepareIndex() {
 		for _, k := range icf.ExtractKeys(cc) {
 			normalizedKey := icf.NormalizeKey(k)
 
-			if assigned, ok := icf.indexedCountryCodes[normalizedKey]; ok {
-				if assigned.Assignment < cc.Assignment {
-					continue
-				}
+			if assigned, ok := icf.indexedCountryCodes[normalizedKey]; ok && assigned.Assignment < cc.Assignment {
+				continue
 			}
 
 			icf.indexedCountryCodes[normalizedKey] = cc

--- a/country/code_fetcher.go
+++ b/country/code_fetcher.go
@@ -134,23 +134,25 @@ func (icf *IndexedCodeFetcher) Search(searchTerm string, operator SearchOperator
 }
 
 func (icf *IndexedCodeFetcher) prepareIndex() {
-	ccs := icf.CountryCodes
+	codes := icf.CountryCodes
 
-	if ccs == nil {
-		ccs = DefaultCountryCodes
+	if codes == nil {
+		codes = DefaultCountryCodes
 	}
 
-	icf.indexedCountryCodes = make(map[string]CountryCode, len(ccs))
+	icf.indexedCountryCodes = make(map[string]CountryCode, len(codes))
 
-	for _, cc := range ccs {
-		for _, k := range icf.ExtractKeys(cc) {
+	for _, code := range codes {
+		for _, k := range icf.ExtractKeys(code) {
 			normalizedKey := icf.NormalizeKey(k)
 
-			if assigned, ok := icf.indexedCountryCodes[normalizedKey]; ok && assigned.Assignment < cc.Assignment {
+			// prevent codes with assignments with smaller priority to overwrite
+			// those with higher priority
+			if cc, ok := icf.indexedCountryCodes[normalizedKey]; ok && cc.Assignment < code.Assignment {
 				continue
 			}
 
-			icf.indexedCountryCodes[normalizedKey] = cc
+			icf.indexedCountryCodes[normalizedKey] = code
 		}
 	}
 }

--- a/country/code_fetcher.go
+++ b/country/code_fetcher.go
@@ -144,7 +144,15 @@ func (icf *IndexedCodeFetcher) prepareIndex() {
 
 	for _, cc := range ccs {
 		for _, k := range icf.ExtractKeys(cc) {
-			icf.indexedCountryCodes[icf.NormalizeKey(k)] = cc
+			normalizedKey := icf.NormalizeKey(k)
+
+			if assigned, ok := icf.indexedCountryCodes[normalizedKey]; ok {
+				if assigned.Assignment < cc.Assignment {
+					continue
+				}
+			}
+
+			icf.indexedCountryCodes[normalizedKey] = cc
 		}
 	}
 }

--- a/country/code_fetcher_test.go
+++ b/country/code_fetcher_test.go
@@ -84,7 +84,7 @@ func TestCodeFetcher_Search(t *testing.T) {
 				mustFetch("UM"),
 				mustFetch("AE"),
 				mustFetch("TZ"),
-				mustFetch("UK"),
+				mustFetch("GB"),
 			},
 		},
 		{


### PR DESCRIPTION
### What does this PR do?

We have two `United Kingdom`s:

```
                {
                        Name:        "United Kingdom",
                        Alpha2:      "GB",
                        Alpha3:      "GBR",
                        Numeric:     826,
                        DialingCode: "+44",
                        Assignment:  OfficiallyAssigned,
                },

		{
			Name:           "United Kingdom",
			Alpha2:         "UK",
			Alpha3:         "",
			Numeric:        -1,
			DialingCode:    "+44",
			Assignment:     ExceptionallyReserved,
			AlternateNames: []string{"Northern Ireland"},
		},
```

Latter overloads the former in `Name`

Fixes #<!-- enter issue number here -->

### What are the observable changes?
<!-- This question could be adequate with multiple use cases, for example: -->

<!-- Frontend: explain the feature created / updated, give instructions telling how to see the change in staging -->
<!-- Performance: what metric should be impacted, link to the right graphana dashboard for exemple -->
<!-- Bug: a given issue trail on sentry should stop happening -->
<!-- Feature: Implements X thrift service / Z HTTP REST API added, provide instructions on how leverage your feature from staging or your workstation -->

### Good PR checklist

- [ ] Title makes sense
- [ ] Is against the correct branch
- [ ] Only addresses one issue
- [ ] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Properly labeled

### Additional Notes

<!--
    You can add anything you want here, an explanation on the way you built your implementation,
    precisions on the origin of the bug, gotchas you need to mention.
 -->
